### PR TITLE
[Issue #310] changed the location of the make_date_utc function becau…

### DIFF
--- a/koalixcrm/accounting/tests/test_accountingModelTest.py
+++ b/koalixcrm/accounting/tests/test_accountingModelTest.py
@@ -5,7 +5,7 @@ from koalixcrm.accounting.models import Account
 from koalixcrm.accounting.models import AccountingPeriod
 from koalixcrm.accounting.models import Booking
 from koalixcrm.crm.documents.pdf_export import PDFExport
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class AccountingModelTest(TestCase):

--- a/koalixcrm/crm/documents/sales_document.py
+++ b/koalixcrm/crm/documents/sales_document.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.contrib import admin, messages
 from django.utils.translation import ugettext as _
 from koalixcrm.crm.const.purpose import *
-from koalixcrm.global_support_functions import xstr
+from koalixcrm.global_support_functions import xstr, make_date_utc
 from koalixcrm.crm.contact.phone_address import PhoneAddress
 from koalixcrm.crm.contact.email_address import EmailAddress
 from koalixcrm.crm.contact.postal_address import PostalAddress
@@ -178,7 +178,7 @@ class SalesDocument(models.Model):
                 new_position.create_position(sales_document_position, self)
 
     def create_pdf(self, template_set, printed_by):
-        self.last_print_date = datetime.now()
+        self.last_print_date = make_date_utc(datetime.now())
         self.save()
         return koalixcrm.crm.documents.pdf_export.PDFExport.create_pdf(self, template_set, printed_by)
 

--- a/koalixcrm/crm/factories/factory_agreement.py
+++ b/koalixcrm/crm/factories/factory_agreement.py
@@ -10,7 +10,7 @@ from koalixcrm.crm.factories.factory_unit import StandardUnitFactory
 from koalixcrm.crm.factories.factory_resource_price import StandardResourcePriceFactory
 from koalixcrm.crm.factories.factory_agreement_type import StandardAgreementTypeFactory
 from koalixcrm.crm.factories.factory_agreement_status import AgreedAgreementStatusFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class StandardAgreementToTaskFactory(factory.django.DjangoModelFactory):

--- a/koalixcrm/crm/factories/factory_estimation.py
+++ b/koalixcrm/crm/factories/factory_estimation.py
@@ -8,7 +8,7 @@ from koalixcrm.crm.factories.factory_human_resource import StandardHumanResource
 from koalixcrm.crm.factories.factory_reporting_period import StandardReportingPeriodFactory
 from koalixcrm.crm.factories.factory_estimation_status import StartedEstimationStatusFactory
 from koalixcrm.crm.factories.factory_task import StandardTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class StandardEstimationToTaskFactory(factory.django.DjangoModelFactory):

--- a/koalixcrm/crm/factories/factory_product_price.py
+++ b/koalixcrm/crm/factories/factory_product_price.py
@@ -7,7 +7,7 @@ from koalixcrm.crm.factories.factory_product import StandardProductFactory
 from koalixcrm.crm.factories.factory_unit import StandardUnitFactory
 from koalixcrm.crm.factories.factory_currency import StandardCurrencyFactory
 from koalixcrm.crm.factories.factory_customer_group import StandardCustomerGroupFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class StandardPriceFactory(factory.django.DjangoModelFactory):

--- a/koalixcrm/crm/factories/factory_product_type.py
+++ b/koalixcrm/crm/factories/factory_product_type.py
@@ -6,7 +6,7 @@ from koalixcrm.crm.models import ProductType
 from koalixcrm.crm.factories.factory_unit import StandardUnitFactory
 from koalixcrm.crm.factories.factory_user import StaffUserFactory
 from koalixcrm.crm.factories.factory_tax import StandardTaxFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class StandardProductTypeFactory(factory.django.DjangoModelFactory):

--- a/koalixcrm/crm/factories/factory_resource_price.py
+++ b/koalixcrm/crm/factories/factory_resource_price.py
@@ -7,7 +7,7 @@ from koalixcrm.crm.factories.factory_resource import StandardResourceFactory
 from koalixcrm.crm.factories.factory_unit import StandardUnitFactory
 from koalixcrm.crm.factories.factory_currency import StandardCurrencyFactory
 from koalixcrm.crm.factories.factory_customer_group import StandardCustomerGroupFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class StandardResourcePriceFactory(factory.django.DjangoModelFactory):

--- a/koalixcrm/crm/factories/factory_sales_document.py
+++ b/koalixcrm/crm/factories/factory_sales_document.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import factory
+import datetime
+from koalixcrm.global_support_functions import make_date_utc
 from koalixcrm.crm.models import SalesDocument
 from koalixcrm.crm.factories.factory_user import StaffUserFactory
 from koalixcrm.crm.factories.factory_contract import StandardContractFactory
@@ -17,17 +19,17 @@ class StandardSalesDocumentFactory(factory.django.DjangoModelFactory):
     external_reference = "This is an external Reference"
     discount = "0"
     description = "This is the description of a sales document"
-    last_pricing_date = "2018-05-01"
+    last_pricing_date = make_date_utc(datetime.datetime(2018, 5, 1, 00))
     last_calculated_price = "220.00"
     last_calculated_tax = "10.00"
     customer = factory.SubFactory(StandardCustomerFactory)
     staff = factory.SubFactory(StaffUserFactory)
     currency = factory.SubFactory(StandardCurrencyFactory)
-    date_of_creation = "2018-05-01"
-    custom_date_field = "2018-05-20"
-    last_modification = "2018-05-25"
+    date_of_creation = make_date_utc(datetime.datetime(2018, 5, 1, 00))
+    custom_date_field = make_date_utc(datetime.datetime(2018, 5, 20, 00))
+    last_modification = make_date_utc(datetime.datetime(2018, 5, 25, 00))
     last_modified_by = factory.SubFactory(StaffUserFactory)
     template_set = factory.SubFactory(StandardQuoteTemplateFactory)
     derived_from_sales_document = None
-    last_print_date = "2018-05-26"
+    last_print_date = make_date_utc(datetime.datetime(2018, 5, 26, 00))
 

--- a/koalixcrm/crm/factories/factory_task.py
+++ b/koalixcrm/crm/factories/factory_task.py
@@ -5,7 +5,7 @@ import datetime
 from koalixcrm.crm.models import Task
 from koalixcrm.crm.factories.factory_project import StandardProjectFactory
 from koalixcrm.crm.factories.factory_task_status import StartedTaskStatusFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class StandardTaskFactory(factory.django.DjangoModelFactory):

--- a/koalixcrm/crm/factories/factory_work.py
+++ b/koalixcrm/crm/factories/factory_work.py
@@ -6,7 +6,7 @@ from koalixcrm.crm.models import Work
 from koalixcrm.crm.factories.factory_task import StandardTaskFactory
 from koalixcrm.crm.factories.factory_reporting_period import StandardReportingPeriodFactory
 from koalixcrm.crm.factories.factory_human_resource import StandardUserExtensionFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class StandardWorkFactory(factory.django.DjangoModelFactory):

--- a/koalixcrm/crm/tests/test_calculations_document.py
+++ b/koalixcrm/crm/tests/test_calculations_document.py
@@ -14,7 +14,7 @@ from koalixcrm.crm.factories.factory_unit import StandardUnitFactory, SmallUnitF
 from koalixcrm.crm.factories.factory_customer_group_transform import StandardCustomerGroupTransformFactory
 from koalixcrm.crm.factories.factory_unit_transform import StandardUnitTransformFactory
 from koalixcrm.crm.factories.factory_currency_transform import StandardCurrencyTransformFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class DocumentCalculationsTest(TestCase):

--- a/koalixcrm/crm/tests/test_incomplete_sales_document_position.py
+++ b/koalixcrm/crm/tests/test_incomplete_sales_document_position.py
@@ -11,7 +11,7 @@ from koalixcrm.crm.factories.factory_customer import StandardCustomerFactory
 from koalixcrm.crm.factories.factory_customer_group import StandardCustomerGroupFactory, AdvancedCustomerGroupFactory
 from koalixcrm.crm.factories.factory_tax import StandardTaxFactory
 from koalixcrm.crm.factories.factory_unit import StandardUnitFactory, SmallUnitFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 from koalixcrm.crm.models import SalesDocumentPosition
 
 

--- a/koalixcrm/crm/tests/test_project_effective_costs.py
+++ b/koalixcrm/crm/tests/test_project_effective_costs.py
@@ -15,7 +15,7 @@ from koalixcrm.crm.factories.factory_resource_price import StandardResourcePrice
 from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
 from koalixcrm.crm.factories.factory_agreement import StandardAgreementToTaskFactory
 from koalixcrm.crm.factories.factory_project import StandardProjectFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class TaskEffectiveCostsWithAgreement(TestCase):

--- a/koalixcrm/crm/tests/test_project_planned_costs.py
+++ b/koalixcrm/crm/tests/test_project_planned_costs.py
@@ -15,12 +15,11 @@ from koalixcrm.crm.factories.factory_resource_price import StandardResourcePrice
 from koalixcrm.crm.factories.factory_project import StandardProjectFactory
 from koalixcrm.crm.factories.factory_unit import StandardUnitFactory
 from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class TaskPlannedEffort(TestCase):
     def setUp(self):
-
         self.test_billing_cycle = StandardCustomerBillingCycleFactory.create()
         self.test_user = AdminUserFactory.create()
         self.test_customer_group = StandardCustomerGroupFactory.create()

--- a/koalixcrm/crm/tests/test_task_effective_costs_no_agreement.py
+++ b/koalixcrm/crm/tests/test_task_effective_costs_no_agreement.py
@@ -13,7 +13,7 @@ from koalixcrm.crm.factories.factory_work import StandardWorkFactory
 from koalixcrm.crm.factories.factory_task import StandardTaskFactory
 from koalixcrm.crm.factories.factory_resource_price import StandardResourcePriceFactory
 from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class TaskEffectiveCostsWithoutAgreement(TestCase):

--- a/koalixcrm/crm/tests/test_task_effective_costs_with_agreement.py
+++ b/koalixcrm/crm/tests/test_task_effective_costs_with_agreement.py
@@ -14,7 +14,7 @@ from koalixcrm.crm.factories.factory_task import StandardTaskFactory
 from koalixcrm.crm.factories.factory_resource_price import StandardResourcePriceFactory
 from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
 from koalixcrm.crm.factories.factory_agreement import StandardAgreementToTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class TaskEffectiveCostsWithAgreement(TestCase):

--- a/koalixcrm/crm/tests/test_task_effective_duration.py
+++ b/koalixcrm/crm/tests/test_task_effective_duration.py
@@ -10,7 +10,7 @@ from koalixcrm.crm.factories.factory_task_status import DoneTaskStatusFactory
 from koalixcrm.crm.factories.factory_reporting_period import StandardReportingPeriodFactory
 from koalixcrm.crm.factories.factory_human_resource import StandardHumanResourceFactory
 from koalixcrm.crm.factories.factory_task import StandardTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
 
 

--- a/koalixcrm/crm/tests/test_task_effective_effort.py
+++ b/koalixcrm/crm/tests/test_task_effective_effort.py
@@ -11,7 +11,7 @@ from koalixcrm.crm.factories.factory_human_resource import StandardHumanResource
 from koalixcrm.crm.factories.factory_work import StandardWorkFactory
 from koalixcrm.crm.factories.factory_task import StandardTaskFactory
 from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class TaskEffectiveEffort(TestCase):

--- a/koalixcrm/crm/tests/test_task_planned_duration.py
+++ b/koalixcrm/crm/tests/test_task_planned_duration.py
@@ -10,7 +10,7 @@ from koalixcrm.crm.factories.factory_reporting_period import StandardReportingPe
 from koalixcrm.djangoUserExtension.factories.factory_user_extension import StandardUserExtensionFactory
 from koalixcrm.crm.factories.factory_task import StandardTaskFactory
 from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 
 
 class TaskPlannedDuration(TestCase):

--- a/koalixcrm/crm/tests/test_task_planned_effort.py
+++ b/koalixcrm/crm/tests/test_task_planned_effort.py
@@ -11,17 +11,10 @@ from koalixcrm.djangoUserExtension.factories.factory_user_extension import Stand
 from koalixcrm.crm.factories.factory_task import StandardTaskFactory
 from koalixcrm.crm.factories.factory_estimation import StandardEstimationToTaskFactory
 from koalixcrm.crm.factories.factory_human_resource import StandardHumanResourceFactory
-from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
 
 
 class TaskPlannedEffort(TestCase):
     def setUp(self):
-        datetime_now = make_date_utc(datetime.datetime(2024, 1, 1, 0, 00))
-        start_date = (datetime_now - datetime.timedelta(days=30)).date()
-        end_date_first_task = (datetime_now + datetime.timedelta(days=30)).date()
-        end_date_second_task = (datetime_now + datetime.timedelta(days=60)).date()
-
         self.test_billing_cycle = StandardCustomerBillingCycleFactory.create()
         self.test_user = AdminUserFactory.create()
         self.test_customer_group = StandardCustomerGroupFactory.create()

--- a/koalixcrm/crm/tests/test_work_delete.py
+++ b/koalixcrm/crm/tests/test_work_delete.py
@@ -12,7 +12,7 @@ from koalixcrm.crm.factories.factory_work import StandardWorkFactory
 from koalixcrm.crm.factories.factory_task import StandardTaskFactory
 from koalixcrm.crm.factories.factory_reporting_period_status import DoneReportingPeriodStatusFactory
 from koalixcrm.crm.factories.factory_estimation import StandardHumanResourceEstimationToTaskFactory
-from koalixcrm.test_support_functions import make_date_utc
+from koalixcrm.global_support_functions import make_date_utc
 from koalixcrm.crm.exceptions import ReportingPeriodDoneDeleteNotPossible
 
 

--- a/koalixcrm/global_support_functions.py
+++ b/koalixcrm/global_support_functions.py
@@ -2,6 +2,8 @@
 
 import datetime
 
+import pytz
+
 
 def limit_string_length(input_string, maximum_length):
     if len(input_string) > maximum_length:
@@ -43,3 +45,8 @@ class ConditionalMethodDecorator(object):
             # Return the function unchanged, not decorated.
             return func
         return self.decorator(func)
+
+
+def make_date_utc(input_date):
+    output_date = pytz.timezone("UTC").localize(input_date, is_dst=None)
+    return output_date

--- a/koalixcrm/test_support_functions.py
+++ b/koalixcrm/test_support_functions.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import pytz
 from selenium.common.exceptions import NoSuchElementException
 import time
 from selenium.common.exceptions import TimeoutException
@@ -31,11 +30,6 @@ def assert_when_element_is_not_equal_to(testcase, xpath, string):
             print("issue")
     except NoSuchElementException:
         return
-
-
-def make_date_utc(input_date):
-    output_date = pytz.timezone("UTC").localize(input_date, is_dst=None)
-    return output_date
 
 
 def create_sales_document_from_reference(test_case,


### PR DESCRIPTION
…se the function is now used also in the productive code

[Issue #310] fixed missing make_date_utc in the factory_sales_document
[Issue #310] new issue needs to be created to fix the remaining timezone-issue on the time-sheet UI